### PR TITLE
Core/PacketIO: Removed timezone adjuments from ReadPackedTime (Shauren)

### DIFF
--- a/src/server/shared/Packets/ByteBuffer.h
+++ b/src/server/shared/Packets/ByteBuffer.h
@@ -524,7 +524,7 @@ class ByteBuffer
             lt.tm_mon = (packedDate >> 20) & 0xF;
             lt.tm_year = ((packedDate >> 24) & 0x1F) + 100;
 
-            return uint32(mktime(&lt) + timezone);
+            return uint32(mktime(&lt));
         }
 
         ByteBuffer& ReadPackedTime(uint32& time)


### PR DESCRIPTION
Player's session timezone offset should be used there, not server offset